### PR TITLE
Update db-migration image in staging

### DIFF
--- a/envs/staging/api.tf
+++ b/envs/staging/api.tf
@@ -3,7 +3,7 @@ locals {
     image_tags = {
       database_layer   = "0.3.78"
       server           = "staging"
-      api_db_migration = "0.20.0-staging.0"
+      api_db_migration = "0.20.1"
     }
   }
 }


### PR DESCRIPTION
To be deployed on 11th April, in order to not run migration in staging that will cost
