### PR TITLE
Do not set timezone query variable for DB layer

### DIFF
--- a/envs/production/api.tf
+++ b/envs/production/api.tf
@@ -45,7 +45,7 @@ module "api" {
   database_layer = {
     image_tag = local.api.image_tags.database_layer
 
-    database_url                   = "mysql://serlo:${var.athene2_database_password_default}@${module.mysql.database_private_ip_address}:3306/serlo?timezone=+00:00"
+    database_url                   = "mysql://serlo:${var.athene2_database_password_default}@${module.mysql.database_private_ip_address}:3306/serlo"
     database_max_connections       = 25
     sentry_dsn                     = "https://849cde772c90451c807ed96a318a935a@o115070.ingest.sentry.io/5649015"
     metadata_api_last_changes_date = "2023-10-26T15:15:00Z"

--- a/envs/staging/api.tf
+++ b/envs/staging/api.tf
@@ -46,7 +46,7 @@ module "api" {
   database_layer = {
     image_tag = local.api.image_tags.database_layer
 
-    database_url                   = "mysql://serlo:${var.athene2_database_password_default}@${module.mysql.database_private_ip_address}:3306/serlo?timezone=+00:00"
+    database_url                   = "mysql://serlo:${var.athene2_database_password_default}@${module.mysql.database_private_ip_address}:3306/serlo"
     database_max_connections       = 25
     sentry_dsn                     = "https://849cde772c90451c807ed96a318a935a@o115070.ingest.sentry.io/5649015"
     metadata_api_last_changes_date = "2023-06-19T12:00:00Z"

--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -140,12 +140,13 @@ module "server" {
   image_pull_policy = var.image_pull_policy
   node_pool         = var.node_pool
 
-  environment                   = var.environment
-  log_level                     = var.log_level
-  redis_url                     = var.redis_url
-  secrets                       = module.secrets
-  sentry_dsn                    = var.server.sentry_dsn
-  serlo_org_database_url        = var.database_layer.database_url
+  environment = var.environment
+  log_level   = var.log_level
+  redis_url   = var.redis_url
+  secrets     = module.secrets
+  sentry_dsn  = var.server.sentry_dsn
+  # TODO: move the timezone query to the declaration of the variable after removing db layer, see #50
+  serlo_org_database_url        = "${var.database_layer.database_url}?timezone=+00:00"
   google_service_account        = var.server.google_service_account
   google_spreadsheet_api        = var.google_spreadsheet_api
   rocket_chat_api               = var.rocket_chat_api
@@ -182,7 +183,8 @@ module "swr_queue_worker" {
   mailchimp_api                 = var.mailchimp_api
   serlo_org_database_layer_host = module.database_layer.host
   concurrency                   = var.swr_queue_worker.concurrency
-  serlo_org_database_url        = var.database_layer.database_url
+  # TODO: move the timezone query to the declaration of the variable after removing db layer, see #50
+  serlo_org_database_url = "${var.database_layer.database_url}?timezone=+00:00"
 }
 
 module "api_db_migration" {


### PR DESCRIPTION
https://github.com/serlo/infra/pull/49 led to a error in database layer:
```
Error: DatabaseError { inner: Database(MySqlDatabaseError 
{ code: Some("42000"), number: 1049, message: "Unknown database 'serlo?timezone=+00:00'"
```
Since database layer is going to be removed anyway in the near future, it is not worthy to try to debug it. So I've just set for api the query variable, and left db layer with the old variable that it always had.
