### PR TITLE
chore: Release db migration 0.21 (uuid on entities)

### DIFF
--- a/envs/production/api.tf
+++ b/envs/production/api.tf
@@ -3,7 +3,7 @@ locals {
     image_tags = {
       database_layer   = "0.3.78"
       server           = "production"
-      api_db_migration = "0.20.1"
+      api_db_migration = "0.21.0"
     }
   }
 }

--- a/envs/staging/api.tf
+++ b/envs/staging/api.tf
@@ -3,7 +3,7 @@ locals {
     image_tags = {
       database_layer   = "0.3.78"
       server           = "staging"
-      api_db_migration = "0.21.0-staging.1"
+      api_db_migration = "0.21.0"
     }
   }
 }


### PR DESCRIPTION
Depends on https://github.com/serlo/db-migrations/pull/339. I checked the newest logs and don't see any bugs! I think it's ready! :ship: 