### PR TITLE
feat: Remove hydra from staging

### DIFF
--- a/envs/staging/auth.tf
+++ b/envs/staging/auth.tf
@@ -1,28 +1,9 @@
 locals {
   ory_chart_version = "0.23.3"
 
-  hydra = {
-    image_tag = "v1.11.8"
-  }
-
   kratos = {
     image_tag = "v1.0.0"
   }
-}
-
-module "hydra" {
-  source = "../../modules/hydra"
-
-  namespace     = kubernetes_namespace.auth_namespace.metadata.0.name
-  chart_version = local.ory_chart_version
-  image_tag     = local.hydra.image_tag
-  node_pool     = module.cluster.node_pools.preemptible
-
-  dsn         = "postgres://${var.postgres_database_username_default}:${var.kpi_kpi_database_password_default}@${module.gcloud_postgres.database_private_ip_address}/hydra"
-  url_login   = "https://${local.domain}/auth/oauth/login"
-  url_logout  = "https://${local.domain}/auth/oauth/logout"
-  url_consent = "https://${local.domain}/auth/oauth/consent"
-  host        = "hydra.${local.domain}"
 }
 
 module "kratos" {


### PR DESCRIPTION
Since the migration of user management, we use hydra just for community chat, 
which in its turn is deployed just in production. So, we can release this resources
in staging.

