### PR TITLE
fix(kratos): remove hack regarding user journey

### DIFF
--- a/modules/kratos/values.yaml
+++ b/modules/kratos/values.yaml
@@ -165,7 +165,6 @@ kratos:
                       config:
                         user: serlo
                         password: ${newsletter_api_key}
-              default_browser_return_url: https://journey.${domain}/auth/login
 
     session:
       lifespan: 720h


### PR DESCRIPTION
Originally, we've done this in order to not having to merge a code in frontend that wouldn't even be needed for our staging. But after https://github.com/serlo/frontend/pull/3730 it will be merged into our code basis in order to avoid this redirection. Anyway, we will deploy this change now in order to allow the testing of the VIDIS-SSO.
