### PR TITLE
Simplify Kratos configuration regarding OIDC

### DIFF
--- a/modules/kratos/main.tf
+++ b/modules/kratos/main.tf
@@ -70,15 +70,13 @@ resource "helm_release" "kratos_deployment" {
         domain          = var.domain
         cookie_secret   = random_password.kratos_cookie_secret.result
         kratos_secret   = random_password.secret.result
-        # TODO: remove ternary operators and sso_enabled variable once we want SSO also in production
-        nbp_client_id               = var.nbp_client.id != "" ? var.nbp_client.id : "anything otherwise the yml will be invalid"
-        nbp_client_secret           = var.nbp_client.secret != "" ? var.nbp_client.secret : "anything otherwise the yml will be invalid"
+        nbp_client_id               = var.nbp_client.id
+        nbp_client_secret           = var.nbp_client.secret
         nbp_user_mapper             = base64encode(file("${path.module}/nbp_user_mapper.jsonnet"))
         vidis_client_id             = var.vidis_client.id
         vidis_client_secret         = var.vidis_client.secret
         vidis_issuer_url            = var.vidis_issuer_url
         vidis_user_mapper           = base64encode(file("${path.module}/vidis_user_mapper.jsonnet"))
-        sso_enabled                 = var.nbp_client.secret != "" ? true : false
         identity_schema             = base64encode(file("${path.module}/identity.schema.json"))
         user_id_mapper              = base64encode("function (ctx) { userId: ctx.identity.id }")
         newsletter_api_key          = var.newsletter_api_key

--- a/modules/kratos/main.tf
+++ b/modules/kratos/main.tf
@@ -61,15 +61,15 @@ resource "helm_release" "kratos_deployment" {
     templatefile(
       "${path.module}/values.yaml",
       {
-        host            = var.host
-        image_tag       = var.image_tag
-        tls_secret_name = kubernetes_secret.kratos_tls_certificate.metadata.0.name
-        dsn             = var.dsn
-        smtp_password   = var.smtp_password
-        namespace       = var.namespace
-        domain          = var.domain
-        cookie_secret   = random_password.kratos_cookie_secret.result
-        kratos_secret   = random_password.secret.result
+        host                        = var.host
+        image_tag                   = var.image_tag
+        tls_secret_name             = kubernetes_secret.kratos_tls_certificate.metadata.0.name
+        dsn                         = var.dsn
+        smtp_password               = var.smtp_password
+        namespace                   = var.namespace
+        domain                      = var.domain
+        cookie_secret               = random_password.kratos_cookie_secret.result
+        kratos_secret               = random_password.secret.result
         nbp_client_id               = var.nbp_client.id
         nbp_client_secret           = var.nbp_client.secret
         nbp_user_mapper             = base64encode(file("${path.module}/nbp_user_mapper.jsonnet"))

--- a/modules/kratos/values.yaml
+++ b/modules/kratos/values.yaml
@@ -52,8 +52,7 @@ kratos:
           config:
             base_url: https://${domain}/api/.ory/
         oidc:
-          # TODO: set `enabled` to true once we want it also in production
-          enabled: ${sso_enabled}
+          enabled: true
           config:
             base_redirect_uri: https://${domain}/api/.ory/
             providers:


### PR DESCRIPTION
We didn't made the TODO (see files), we are just removing the logic from here and putting it into frontend, in order to simplify our code. With that we prepare also a possible deployment of the VIDIS SSO at serlo.org.

### Before deploying
- [x] change the terraform secrets so that `nbp_client.id` and `.secret `receive a placeholder

### Blocker
- [x] https://github.com/serlo/frontend/pull/3853