### PR TITLE
Fix annoying warning regarding ingress-nginx

### DIFF
--- a/modules/ingress-nginx/versions.tf
+++ b/modules/ingress-nginx/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_version = ">= 1.0"
   required_providers {
-    kubernetes = {
+    helm = {
       source  = "hashicorp/helm"
       version = ">= 2.0"
     }


### PR DESCRIPTION
This warning won't appear anymore:
```
 Warning: Duplicate required provider
│ 
│   on ../../modules/ingress-nginx/main.tf line 7:
│    7: resource "helm_release" "ingress_nginx" {
│ 
│ Provider "registry.terraform.io/hashicorp/helm" was implicitly required via resource "helm_release.ingress_nginx", but listed in required_providers as "kubernetes". Either the local name in
│ required_providers must match the resource name, or the "kubernetes" provider must be assigned within the resource block.
```
