### PR TITLE
db-migrations: make the it run ealier

### DIFF
--- a/modules/api/api-db-migration/main.tf
+++ b/modules/api/api-db-migration/main.tf
@@ -130,7 +130,7 @@ resource "kubernetes_cron_job_v1" "migration_cron_job" {
 
   spec {
     concurrency_policy = "Forbid"
-    schedule           = "0 5 * * *"
+    schedule           = "0 3 * * *"
     job_template {
       metadata {}
       spec {


### PR DESCRIPTION
The pods are in UTC.
Because of summer time it is actually running at 7 o'Clock in Germany.
If the migration takes long, it may conflict with someone working early.

Since the dbsetup is anyway set to [2 am](https://github.com/serlo/db-migrations/pull/352/commits/6eb6c3777f7d4ae71cbecf442d34d73d8abd85ad) (it means 4 pm in Germany) it should be ok.
