### PR TITLE
Fix dbsetup error with foreign key

### DIFF
--- a/envs/staging/editor.tf
+++ b/envs/staging/editor.tf
@@ -5,6 +5,8 @@ module "editor" {
   node_pool = module.cluster.node_pools.non-preemptible
 
   dev_mode = true
+
+  lti_platform_client_id = var.editor_lti_platform_client_id
 }
 
 module "editor_ingress" {

--- a/envs/staging/main.tf
+++ b/envs/staging/main.tf
@@ -74,7 +74,7 @@ module "gcloud_postgres" {
 
 module "athene2_dbsetup" {
   source    = "../../modules/dbsetup"
-  image     = "eu.gcr.io/serlo-shared/athene2-dbsetup-cronjob:3.1.1"
+  image     = "eu.gcr.io/serlo-shared/athene2-dbsetup-cronjob:3.1.2"
   namespace = kubernetes_namespace.api_namespace.metadata.0.name
   node_pool = module.cluster.node_pools.preemptible
   schedule  = "0 2 * * *"

--- a/envs/staging/variables.tf
+++ b/envs/staging/variables.tf
@@ -118,3 +118,7 @@ variable "slack_token" {
   type      = string
   sensitive = true
 }
+
+variable "editor_lti_platform_client_id" {
+  type = string
+}

--- a/images/dbsetup/Dockerfile
+++ b/images/dbsetup/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.17.2
 RUN apk update && apk add bash curl python3 python3-dev py-pip build-base && rm -rf /var/cache/apk/*
 RUN curl https://sdk.cloud.google.com | bash >/dev/null
 ENV PATH=${PATH}:/root/google-cloud-sdk/bin:/root/google-cloud-sdk/platform/gsutil
-RUN apk update && apk add mysql-client postgresql-client unzip && rm -rf /var/cache/apk/*
+RUN apk update && apk add mysql-client postgresql-client unzip mariadb-connector-c-dev && rm -rf /var/cache/apk/*
 
 WORKDIR /tmp
 COPY . .

--- a/images/dbsetup/Makefile
+++ b/images/dbsetup/Makefile
@@ -3,7 +3,7 @@ local_image=serlo/$(image_name)
 
 major_version=3
 minor_version=1
-patch_version=1
+patch_version=2
 version=$(major_version).$(minor_version).$(patch_version)
 
 include ../docker.mk

--- a/images/dbsetup/run.sh
+++ b/images/dbsetup/run.sh
@@ -17,9 +17,6 @@ until mysql $mysql_connect -e "SHOW DATABASES" >/dev/null 2>/dev/null; do
     sleep 10
 done
 
-log_info "create serlo database if it's not there yet"
-mysql $mysql_connect -e "CREATE DATABASE IF NOT EXISTS serlo"
-
 [ -z "GCLOUD_BUCKET_URL" ] && {
     log_fatal "GCLOUD_BUCKET_URL not given"
     exit 1
@@ -41,6 +38,11 @@ unzip -o "/tmp/$newest_dump" -d /tmp || {
     log_fatal "unzip of dump file failed"
     exit 1
 }
+
+log_info "Recreating serlo database"
+mysql $mysql_connect -e "DROP DATABASE serlo"
+mysql $mysql_connect -e "CREATE DATABASE serlo"
+
 mysql $mysql_connect serlo <"/tmp/mysql.sql" || {
     log_fatal "import of dump failed"
     exit 1

--- a/modules/editor-as-lti-tool/main.tf
+++ b/modules/editor-as-lti-tool/main.tf
@@ -1,6 +1,9 @@
 locals {
   name      = "editor-as-lti-tool"
   image_tag = var.dev_mode ? "dev" : "latest"
+
+  lti_platform_url = "https://identityserver.itslearning.com"
+
 }
 
 variable "namespace" {
@@ -13,6 +16,10 @@ variable "node_pool" {
 
 variable "dev_mode" {
   type = bool
+}
+
+variable "lti_platform_client_id" {
+  type = string
 }
 
 output "editor_service_name" {
@@ -68,8 +75,31 @@ resource "kubernetes_deployment" "editor_as_lti_tool" {
           env {
             name  = "MONGODB_CONNECTION_URI"
             value = "mongodb://root:${random_password.mongodb_root_password.result}@${helm_release.database.name}:27017/?authSource=admin&readPreference=primary&ssl=false"
-
           }
+          env {
+              name  = "LTI_PLATFORM_URL"
+              value = local.lti_platform_url
+            }
+          env {
+              name  = "LTI_PLATFORM_NAME"
+              value = "itslearning.com"
+            }
+          env {
+              name  = "LTI_PLATFORM_CLIENT_ID"
+              value = var.lti_platform_client_id
+            }
+          env {
+              name  = "LTI_PLATFORM_AUTHENTICATION_ENDPOINT"
+              value = "${local.lti_platform_url}/connect/authorize"
+            }
+          env {
+              name  = "LTI_PLATFORM_ACCESS_TOKEN_ENDPOINT"
+              value = "${local.lti_platform_url}/connect/token"
+            }
+          env {
+              name  = "LTI_PLATFORM_KEYSET_ENDPOINT"
+              value = "${local.lti_platform_url}/.well-known/openid-configuration/jwks"
+            }
         }
       }
     }

--- a/modules/editor-as-lti-tool/main.tf
+++ b/modules/editor-as-lti-tool/main.tf
@@ -77,29 +77,29 @@ resource "kubernetes_deployment" "editor_as_lti_tool" {
             value = "mongodb://root:${random_password.mongodb_root_password.result}@${helm_release.database.name}:27017/?authSource=admin&readPreference=primary&ssl=false"
           }
           env {
-              name  = "LTI_PLATFORM_URL"
-              value = local.lti_platform_url
-            }
+            name  = "LTI_PLATFORM_URL"
+            value = local.lti_platform_url
+          }
           env {
-              name  = "LTI_PLATFORM_NAME"
-              value = "itslearning.com"
-            }
+            name  = "LTI_PLATFORM_NAME"
+            value = "itslearning.com"
+          }
           env {
-              name  = "LTI_PLATFORM_CLIENT_ID"
-              value = var.lti_platform_client_id
-            }
+            name  = "LTI_PLATFORM_CLIENT_ID"
+            value = var.lti_platform_client_id
+          }
           env {
-              name  = "LTI_PLATFORM_AUTHENTICATION_ENDPOINT"
-              value = "${local.lti_platform_url}/connect/authorize"
-            }
+            name  = "LTI_PLATFORM_AUTHENTICATION_ENDPOINT"
+            value = "${local.lti_platform_url}/connect/authorize"
+          }
           env {
-              name  = "LTI_PLATFORM_ACCESS_TOKEN_ENDPOINT"
-              value = "${local.lti_platform_url}/connect/token"
-            }
+            name  = "LTI_PLATFORM_ACCESS_TOKEN_ENDPOINT"
+            value = "${local.lti_platform_url}/connect/token"
+          }
           env {
-              name  = "LTI_PLATFORM_KEYSET_ENDPOINT"
-              value = "${local.lti_platform_url}/.well-known/openid-configuration/jwks"
-            }
+            name  = "LTI_PLATFORM_KEYSET_ENDPOINT"
+            value = "${local.lti_platform_url}/.well-known/openid-configuration/jwks"
+          }
         }
       }
     }


### PR DESCRIPTION
It seems to happen because dump dropped each table and afterwards creates it, instead of dropping
the whole database. So it tries to create a foreign key constraint on a table that still have
the old schema, before it was renamed.