### PR TITLE
db: change to another bucket

### DIFF
--- a/envs/production/main.tf
+++ b/envs/production/main.tf
@@ -77,7 +77,7 @@ module "athene2-dbdump" {
     password = var.kpi_kpi_database_password_readonly
   }
   bucket = {
-    url                 = "gs://anonymous-data"
+    url                 = "gs://anonymous-dump"
     service_account_key = module.gcloud_dbdump_writer.account_key
   }
 }

--- a/modules/gcloud/gcloud_dbdump_writer/main.tf
+++ b/modules/gcloud/gcloud_dbdump_writer/main.tf
@@ -8,7 +8,7 @@ resource "google_service_account_key" "dbdump_writer_key" {
 }
 
 resource "google_storage_bucket_iam_binding" "dbdump_writer_binding" {
-  bucket = "anonymous-data"
+  bucket = "anonymous-dump"
   role   = "roles/storage.objectAdmin"
 
   members = ["serviceAccount:${google_service_account.dbdump_writer.email}"]


### PR DESCRIPTION
We are transfering the anonymous db data to another bucket, in order to close the project serlo-shared and so saving money.
