### PR TITLE
Upgrade postgresql peu a peu and kratos

### DIFF
--- a/envs/terraform.mk
+++ b/envs/terraform.mk
@@ -29,11 +29,6 @@ terraform_apply_without_downloading_secrets:
 	terraform fmt -recursive
 	terraform apply -var-file secrets/terraform-$(env_name).tfvars
 
-.PHONY: terraform_destroy
-terraform_destroy:
-	terraform fmt -recursive
-	terraform destroy -var-file secrets/terraform-$(env_name).tfvars
-
 .PHONY: terraform_download_secrets
 terraform_download_secrets:
 	rm -rf secrets

--- a/modules/gcloud/gcloud_postgres/main.tf
+++ b/modules/gcloud/gcloud_postgres/main.tf
@@ -1,6 +1,6 @@
 resource "google_sql_database_instance" "db" {
   name             = var.database_instance_name
-  database_version = "POSTGRES_11"
+  database_version = "POSTGRES_12"
   region           = var.database_region
 
   lifecycle {

--- a/modules/gcloud/gcloud_postgres/main.tf
+++ b/modules/gcloud/gcloud_postgres/main.tf
@@ -1,6 +1,6 @@
 resource "google_sql_database_instance" "db" {
   name             = var.database_instance_name
-  database_version = "POSTGRES_9_6"
+  database_version = "POSTGRES_10_23"
   region           = var.database_region
 
   lifecycle {

--- a/modules/gcloud/gcloud_postgres/main.tf
+++ b/modules/gcloud/gcloud_postgres/main.tf
@@ -1,6 +1,6 @@
 resource "google_sql_database_instance" "db" {
   name             = var.database_instance_name
-  database_version = "POSTGRES_10_23"
+  database_version = "POSTGRES_11"
   region           = var.database_region
 
   lifecycle {


### PR DESCRIPTION
For some reason, upgrading has to be manual in the UI.

- [x] Deploy postgres 10 in staging and production
- [x] Deploy postgres 11 in staging and production
- [x] Deploy postgres 12 in staging and production
- [x] Upgrade kratos (which is dependent of a higher version of postgres)
