### PR TITLE
Upgrade rocket chat to v. 7

### DIFF
--- a/envs/production/rocket-chat.tf
+++ b/envs/production/rocket-chat.tf
@@ -2,7 +2,7 @@ locals {
   rocket_chat = {
     chart_versions = {
       rocketchat = "4.7.4"
-      mongodb    = "14.0.0"
+      mongodb    = "14.0.14"
     }
     image_tags = {
       rocketchat = "6.13.0"

--- a/envs/production/rocket-chat.tf
+++ b/envs/production/rocket-chat.tf
@@ -6,7 +6,7 @@ locals {
     }
     image_tags = {
       rocketchat = "6.13.0"
-      mongodb    = "5.0.24"
+      mongodb    = "6.0.0"
     }
   }
 }

--- a/envs/production/rocket-chat.tf
+++ b/envs/production/rocket-chat.tf
@@ -5,7 +5,7 @@ locals {
       mongodb    = "14.0.14"
     }
     image_tags = {
-      rocketchat = "6.13.0"
+      rocketchat = "7.3.2"
       mongodb    = "6.0.0"
     }
   }

--- a/envs/production/rocket-chat.tf
+++ b/envs/production/rocket-chat.tf
@@ -2,7 +2,7 @@ locals {
   rocket_chat = {
     chart_versions = {
       rocketchat = "4.7.4"
-      mongodb    = "11.0.0"
+      mongodb    = "14.0.0"
     }
     image_tags = {
       rocketchat = "6.13.0"

--- a/modules/rocket-chat/values-mongodb.yaml
+++ b/modules/rocket-chat/values-mongodb.yaml
@@ -15,7 +15,7 @@ readinessProbe:
   timeoutSeconds: 20
 resources:
   requests:
-    cpu: 350m
+    cpu: 100m
     memory: 500Mi
   limits:
     cpu: 500m

--- a/modules/rocket-chat/values-mongodb.yaml
+++ b/modules/rocket-chat/values-mongodb.yaml
@@ -9,6 +9,8 @@ auth:
   password: ${mongodb_password}
   database: ${mongodb_database}
   replicaSetKey: ${mongodb_replica_set_key}
+readinessProbe:
+  timeoutSeconds: 20
 resources:
   requests:
     cpu: 200m

--- a/modules/rocket-chat/values-mongodb.yaml
+++ b/modules/rocket-chat/values-mongodb.yaml
@@ -13,8 +13,8 @@ readinessProbe:
   timeoutSeconds: 20
 resources:
   requests:
-    cpu: 200m
+    cpu: 350m
     memory: 500Mi
   limits:
-    cpu: 350m
+    cpu: 500m
     memory: 1000Mi

--- a/modules/rocket-chat/values-mongodb.yaml
+++ b/modules/rocket-chat/values-mongodb.yaml
@@ -16,5 +16,5 @@ resources:
     cpu: 200m
     memory: 500Mi
   limits:
-    cpu: 250m
+    cpu: 350m
     memory: 1000Mi

--- a/modules/rocket-chat/values-mongodb.yaml
+++ b/modules/rocket-chat/values-mongodb.yaml
@@ -1,5 +1,7 @@
 image:
   tag: ${image_tag}
+extraFlags:
+  - "--wiredTigerCacheSizeGB=2"
 architecture: replicaset
 nodeSelector:
   cloud.google.com/gke-nodepool: ${node_pool}

--- a/modules/rocket-chat/values-rocketchat.yaml
+++ b/modules/rocket-chat/values-rocketchat.yaml
@@ -14,7 +14,7 @@ smtp:
 
 resources:
   requests:
-    cpu: 300m
+    cpu: 150m
     memory: 1000Mi
   limits:
     cpu: 350m


### PR DESCRIPTION
Just for the records

The main issue while upgrading was the upgrade of MongoDB. 
The secondary replica was always failing at the initial sync. The diagnostic was: the data is already too big and syncing times out.
The solution was 
1. use the command to overwrite the initial command of image, setting `sleep infinity`. 
2. manually copy the data at `/bitnami/mongodb/data/db` of the primary to the local machine and then to the same directory at the secondary.
3. Reset command.